### PR TITLE
Delay setting of low detail mode

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lowmemory/LowMemoryPlugin.java
@@ -42,12 +42,6 @@ public class LowMemoryPlugin extends Plugin
 	private Client client;
 
 	@Override
-	protected void startUp() throws Exception
-	{
-		client.changeMemoryMode(true);
-	}
-
-	@Override
 	protected void shutDown() throws Exception
 	{
 		client.changeMemoryMode(false);


### PR DESCRIPTION
To not change low detail flag before sounds are loaded, delay it to be
set only when arriving at login screen to not end up with corrupted
sound data.

Fixes: #696

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>