### PR TITLE
Store markers based on epoch millis

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarker.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarker.java
@@ -35,6 +35,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ScreenMarker
 {
+	private long id;
 	private String name;
 	private int borderThickness;
 	private Color color;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerOverlay.java
@@ -52,7 +52,7 @@ public class ScreenMarkerOverlay extends Overlay
 	@Override
 	public String getName()
 	{
-		return marker.getName();
+		return "marker" + marker.getId();
 	}
 
 	@Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/screenmarkers/ScreenMarkerPlugin.java
@@ -33,6 +33,7 @@ import com.google.gson.reflect.TypeToken;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -170,6 +171,7 @@ public class ScreenMarkerPlugin extends Plugin
 	public void startCreation(Point location)
 	{
 		currentMarker = new ScreenMarker(
+			Instant.now().toEpochMilli(),
 			DEFAULT_MARKER_NAME + " " + (screenMarkers.size() + 1),
 			pluginPanel.getSelectedBorderThickness(),
 			pluginPanel.getSelectedColor(),


### PR DESCRIPTION
To create fully unique identifier, store markers based on epoch millis
instead of using their name, to allow renaming.

Signed-off-by: Tomas Slusny <slusnucky@gmail.com>